### PR TITLE
Get Python support working for blockly

### DIFF
--- a/www/blocs&generateurs/otto.js
+++ b/www/blocs&generateurs/otto.js
@@ -13,7 +13,7 @@ Blockly.Blocks['otto9_home'] = {init: function() {
     this.setInputsInline(false);
     this.setPreviousStatement(true);
     this.setNextStatement(true);
-  this.setColour("#32D900");
+    this.setColour("#32D900");
     this.setTooltip(Blockly.Msg.OTTO9_HOME_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.OTTO9_DIY_URL);  }
 };
@@ -31,6 +31,14 @@ Blockly.Arduino['otto9_home'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='Otto.init(PIN_YL, PIN_YR, PIN_RL, PIN_RR, true, A6, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
   var code = 'Otto.home();\n';
   return code;
+};
+
+Blockly.Python['otto9_home'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = "Otto.home()\n";
+    return code;
 };
 
 Blockly.Blocks['otto9_calibration']={init:function(){
@@ -66,13 +74,25 @@ Blockly.Arduino['otto9_calibration']=function(block){
   return code;
 };
 
+Blockly.Python['otto9_calibration'] = function(block) {
+    var valuell = block.getFieldValue('LL');
+    var valuerl = block.getFieldValue('RL');
+    var valuelf = block.getFieldValue('LF');
+    var valuerf = block.getFieldValue('RF');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.setTrims('+ valuell +','+ valuerl +',' +valuelf +','+ valuerf+')\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_eeprom'] = {init: function() {
     this.appendDummyInput("")  .appendField(Blockly.Msg.OTTO9_EEPROM_TEXT);
     this.setInputsInline(false);
     this.setPreviousStatement(true);
     this.setNextStatement(true);
     this.setColour("#ff6600");
-    this.setTooltip(Blockly.Msg.OTTO9_EEEPROM_TOOLTIP);
+    this.setTooltip(Blockly.Msg.OTTO9_EEPROM_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.OTTO9_DIY_URL);}
 };
 
@@ -80,6 +100,12 @@ Blockly.Arduino['otto9_eeprom'] = function(block) {
   Blockly.Arduino.setups_['otto9_eeprom']='Otto.saveTrimsOnEEPROM();';
   var code = '//calibration saved\n';
   return code;
+};
+
+Blockly.Python['otto9_eeprom'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    var code = 'Otto.saveTrimsOnEEPROM()\n';
+    return code;
 };
 
 Blockly.Blocks['otto9_move'] = {init: function() {
@@ -141,6 +167,45 @@ Blockly.Arduino['otto9_move'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_move'] = function(block) {
+    var dropdown_otto_move_sens = block.getFieldValue('otto_move_sens');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = '';
+    switch(dropdown_otto_move_sens) {
+        case 'FORWARD':
+            code = 'Otto.walk(1,' + dropdown_otto_move_speed + ',1) # FORWARD\n';
+            break;
+        case 'BACKWARD':
+            code = 'Otto.walk(1,' + dropdown_otto_move_speed + ',-1) # BACKWARD\n';
+            break;
+        case 'LEFT':
+            code = 'Otto.turn(1,' + dropdown_otto_move_speed + ',1) # LEFT\n';
+            break;
+        case 'RIGHT':
+            code = 'Otto.turn(1,' + dropdown_otto_move_speed + ',-1) # RIGHT\n';
+            break;
+        case 'BENDLEFT':
+            code = 'Otto.bend(1,' + dropdown_otto_move_speed + ',1)\n';
+            break;
+        case 'BENDRIGHT':
+            code = 'Otto.bend(1,' + dropdown_otto_move_speed + ',-1)\n';
+            break;
+        case 'SHAKERIGHT':
+            code = 'Otto.shakeLeg(1,' + dropdown_otto_move_speed + ',1)\n';
+            break;
+        case 'SHAKELEFT':
+            code = 'Otto.shakeLeg(1,' + dropdown_otto_move_speed + ',-1)\n';
+            break;
+        case 'jump':
+            code = 'Otto.jump(1,' + dropdown_otto_move_speed + ')\n';
+            break;
+    }
+    return code;
+};
+
 Blockly.Blocks['otto9_dance'] = {
   init: function() {
     this.appendDummyInput().appendField(new Blockly.FieldImage('media/otto_moonwalk.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_DANCE_TEXT)
@@ -196,6 +261,36 @@ Blockly.Arduino['otto9_dance'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_dance'] = function(block) {
+    var dropdown_otto_dance_movement = block.getFieldValue('otto_dance_movement');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = '';
+    switch(dropdown_otto_dance_movement) {
+        case 'moonwalkerLEFT':
+            code = 'Otto.moonwalker(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'moonwalkerRIGHT':
+            code = 'Otto.moonwalker(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+        case 'crusaitoLEFT':
+            code = 'Otto.crusaito(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'crusaitoRIGHT':
+            code = 'Otto.crusaito(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+        case 'flappingFRONT':
+            code = 'Otto.flapping(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'flappingBACK':
+            code = 'Otto.flapping(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+    }
+    return code;
+};
 
 Blockly.Blocks['otto9_do'] = {init: function() {
     this.appendDummyInput()
@@ -212,6 +307,7 @@ Blockly.Blocks['otto9_do'] = {init: function() {
     this.setTooltip(Blockly.Msg.OTTO9_DO_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.OTTO9_DIY_URL);  }
 };
+
 Blockly.Arduino['otto9_do'] = function(block) {
   var dropdown_otto_do_movement = block.getFieldValue('otto_do_movement');
   var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
@@ -229,6 +325,18 @@ Blockly.Arduino['otto9_do'] = function(block) {
   var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ');\n';
   return code;
 };
+
+Blockly.Python['otto9_do'] = function(block) {
+    var dropdown_otto_do_movement = block.getFieldValue('otto_do_movement');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ')\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_gesture'] = {init: function() {
     this.appendDummyInput() .appendField(new Blockly.FieldImage('media/otto_emoji.png', 22, 22, "*")).appendField(Blockly.Msg.OTTO9_GESTURE_TEXT) .appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_GESTURE_CHOICE), "otto_gesture");
     this.setInputsInline(true);
@@ -253,6 +361,16 @@ Blockly.Arduino['otto9_gesture'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='Otto.init(PIN_YL, PIN_YR, PIN_RL, PIN_RR, true, A6, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
   var code = 'Otto.playGesture(' + dropdown_otto_gesture + ');\n';
   return code;
+};
+
+Blockly.Python['otto9_gesture'] = function(block) {
+    var dropdown_otto_gesture = block.getFieldValue('otto_gesture');
+    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_gestures'] = 'import gestures';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.playGesture(' + 'gestures.' + dropdown_otto_gesture.toUpperCase() + ')\n';
+    return code;
 };
 
 Blockly.Blocks['otto9_sound'] = {init: function() {
@@ -281,6 +399,16 @@ Blockly.Arduino['otto9_sound'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_sound'] = function(block) {
+    var dropdown_otto_sound = block.getFieldValue('otto_sound');
+    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_songs'] = 'import songs';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.sing(songs.' + dropdown_otto_sound.toUpperCase().substring(2) + ')\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_tone'] = {init: function() {
     this.appendDummyInput().appendField("🎼")
         .appendField(new Blockly.FieldDropdown([["C4", "262"], ["D4", "294"], ["E4", "330"], ["F4", "349"], ["G4", "392"], ["A4", "440"], ["B4", "494"], ["C5", "523"], ["D5", "587"] ,["E5", "659"], ["F5", "698"], ["G5", "784"], ["A5", "880"], ["B5", "988"], ["C6", "1047"], ["D6", "1175"], ["E6", "1319"], ["F6", "1397"], ["G6", "1568"], ["A6", "1760"], ["B6", "1976"]]), "otto_note");
@@ -296,19 +424,30 @@ Blockly.Blocks['otto9_tone'] = {init: function() {
 };
 
 Blockly.Arduino['otto9_tone'] = function(block) {
-  var dropdown_otto_note = block.getFieldValue('otto_note');
-  var dropdown_otto_note_duration = block.getFieldValue('otto_note_duration');
-  Blockly.Arduino.includes_['otto9_lib'] = '#include <Otto9.h>\n'
-	+ 'Otto9 Otto;';
-  Blockly.Arduino.definitions_['otto9_legs'] = '#define PIN_YL 2 // left leg, servo[0]\n'
-	+ '#define PIN_YR 3 // right leg, servo[1]\n'
-	+ '#define PIN_RL 4 // left foot, servo[2]\n'
-	+ '#define PIN_RR 5 // right foot, servo[3]\n'
-  + '#define PIN_Trigger 8 // ultrasound \n'
-  + '#define PIN_Echo 9 // ultrasound \n'
-  + '#define PIN_Buzzer  13 //buzzer';
-  Blockly.Arduino.setups_['otto9_init']='Otto.init(PIN_YL, PIN_YR, PIN_RL, PIN_RR, true, A6, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
-  return   "Otto._tone( " + dropdown_otto_note + "," + dropdown_otto_note_duration + ",1);\n";
+    var dropdown_otto_note = block.getFieldValue('otto_note');
+    var dropdown_otto_note_duration = block.getFieldValue('otto_note_duration');
+    Blockly.Arduino.includes_['otto9_lib'] = '#include <Otto9.h>\n'
+        + 'Otto9 Otto;';
+    Blockly.Arduino.definitions_['otto9_legs'] = '#define PIN_YL 2 // left leg, servo[0]\n'
+        + '#define PIN_YR 3 // right leg, servo[1]\n'
+        + '#define PIN_RL 4 // left foot, servo[2]\n'
+        + '#define PIN_RR 5 // right foot, servo[3]\n'
+        + '#define PIN_Trigger 8 // ultrasound \n'
+        + '#define PIN_Echo 9 // ultrasound \n'
+        + '#define PIN_Buzzer  13 //buzzer';
+    Blockly.Arduino.setups_['otto9_init']='Otto.init(PIN_YL, PIN_YR, PIN_RL, PIN_RR, true, A6, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
+    var code = "Otto._tone( " + dropdown_otto_note + "," + dropdown_otto_note_duration + ",1);\n";
+    return code;
+};
+
+Blockly.Python['otto9_tone'] = function(block) {
+    var dropdown_otto_note = block.getFieldValue('otto_note');
+    var dropdown_otto_note_duration = block.getFieldValue('otto_note_duration');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = "Otto._tone(" + dropdown_otto_note + ", " + dropdown_otto_note_duration + ", 1)\n";
+    return code;
 };
 
 Blockly.Blocks['otto9_getdistance'] = {init: function() {
@@ -319,6 +458,7 @@ Blockly.Blocks['otto9_getdistance'] = {init: function() {
     this.setTooltip(Blockly.Msg.OTTO9_GETDISTANCE_TOOLTIP);
     this.setHelpUrl(Blockly.Msg.OTTO9_DIY_URL);}
 };
+
 Blockly.Arduino['otto9_getdistance'] = function(block) {
   Blockly.Arduino.includes_['otto9_lib_dist'] = '#include <US.h>';
   Blockly.Arduino.variables_['otto9_distance'] = 'int distance;\n'
@@ -328,6 +468,15 @@ Blockly.Arduino['otto9_getdistance'] = function(block) {
   var code = 'Otto.getDistance()';
   return [code, Blockly.Arduino.ORDER_ATOMIC];
 };
+
+Blockly.Python['otto9_getdistance'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+    + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.getDistance()\n';
+    return [code, Blockly.Python.ORDER_ATOMIC];
+};
+
 Blockly.Blocks['otto9_obstacle'] = {init: function() {
     this.appendDummyInput().appendField(new Blockly.FieldImage('media/sensor_ultrasound.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_GETOBSTACLE_TEXT)
         .appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_OBSTACLE_CHOICE), "obstacle");
@@ -338,6 +487,7 @@ Blockly.Blocks['otto9_obstacle'] = {init: function() {
     this.setHelpUrl(Blockly.Msg.OTTO9_DIY_URL);
   }
 };
+
 Blockly.Arduino['otto9_obstacle'] = function(block) {
   var dropdown_obstacle = block.getFieldValue('obstacle');
   Blockly.Arduino.includes_['otto9_lib_dist'] = '#include <US.h>';
@@ -345,8 +495,17 @@ Blockly.Arduino['otto9_obstacle'] = function(block) {
 	+ 'bool obstacleDetected = false;';
   Blockly.Arduino.definitions_['otto9_distance'] = '#define PIN_Trigger 8 // ultrasound \n'
 	+ '#define PIN_Echo 9 // ultrasound';
-  var code = '(Otto.getDistance() <' + dropdown_obstacle+')';
+  var code = '(Otto.getDistance() <' + dropdown_obstacle +')';
   return [code, Blockly.Arduino.ORDER_ATOMIC];
+};
+
+Blockly.Python['otto9_obstacle'] = function(block) {
+    var dropdown_obstacle = block.getFieldValue('obstacle');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = '(Otto.getDistance() < ' + dropdown_obstacle +')';
+    return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Blocks['otto9_getnoise'] = {init: function() {
@@ -358,11 +517,20 @@ Blockly.Blocks['otto9_getnoise'] = {init: function() {
     this.setHelpUrl(Blockly.Msg.OTTO9_HUMANOID_URL);
   }
 };
+
 Blockly.Arduino['otto9_getnoise'] = function(block) {
-  Blockly.Arduino.variables_['otto9_noise'] = 'bool estado = false;';
-  Blockly.Arduino.definitions_['otto9_noise'] = '#define PIN_NoiseSensor A6';
-  var code = 'Otto.getNoise()';
-  return [code, Blockly.Arduino.ORDER_ATOMIC];
+    Blockly.Arduino.variables_['otto9_noise'] = 'bool estado = false;';
+    Blockly.Arduino.definitions_['otto9_noise'] = '#define PIN_NoiseSensor A6';
+    var code = 'Otto.getNoise()';
+    return [code, Blockly.Arduino.ORDER_ATOMIC];
+};
+
+Blockly.Python['otto9_getnoise'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = 'Otto.getNoise()';
+    return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
 Blockly.Blocks['otto9_touchbutton'] = {init: function() {
@@ -380,6 +548,15 @@ Blockly.Arduino['otto9_touchbutton'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='pinMode(PIN_Button, INPUT);\n';
   var code = 'digitalRead(PIN_Button)';
   return [code, Blockly.Arduino.ORDER_ATOMIC];
+};
+
+Blockly.Python['otto9_touchbutton'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['touch_pin'] = 'touch1 = TouchPad(Pin(14))'
+    var code = 'touch1.read()';
+    return [code, Blockly.Arduino.ORDER_ATOMIC];
 };
 
 Blockly.Blocks['otto9_gyro'] = {init: function() {
@@ -409,6 +586,14 @@ Blockly.Arduino['otto9_gyro'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_gyro'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    var code = "print('we don\'t yet support gyro') # We don't yet support gyro in Python\n";
+    return code;
+};
+
 Blockly.Blocks['otto9_getg'] = {init: function() {
     this.appendDummyInput().appendField(new Blockly.FieldImage('media/sensor_gyro.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_GETG_TEXT).appendField(new Blockly.FieldDropdown([["ax", "ax"], ["ay", "ay"], ["az", "az"], ["gx", "gx"], ["gy", "gy"], ["gz", "gz"]]), "otto_getg");
     this.setInputsInline(true);
@@ -435,6 +620,15 @@ Blockly.Arduino['otto9_getg'] = function(block) {
   var code = dropdown_otto_getg;
   return [code, Blockly.Arduino.ORDER_ATOMIC];
 };
+
+Blockly.Python['otto9_getg'] = function(block) {
+Blockly.Python.definitions_['import_otto']='import otto9';
+Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
+    + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+var code = "print('we don\'t yet support gyro') # We don't yet support gyro in Python\n";
+return code;
+};
+
 Blockly.Blocks['otto9_homeh'] = { init: function() {
     this.appendDummyInput("") .appendField(new Blockly.FieldImage('media/humanoid.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_HOME_TEXT);
     this.setInputsInline(false);
@@ -460,6 +654,14 @@ Blockly.Arduino['otto9_homeh'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='Otto.initHUMANOID(PIN_YL, PIN_YR, PIN_RL, PIN_RR, PIN_LA, PIN_RA, true, PIN_NoiseSensor, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
   var code = 'Otto.home();\n';
   return code;
+};
+
+Blockly.Python['otto9_homeh'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = "Otto.home()\n";
+    return code;
 };
 
 Blockly.Blocks['otto9_calibrationh']={ init:function(){
@@ -497,6 +699,20 @@ Blockly.Arduino['otto9_calibrationh']=function(block){
   Blockly.Arduino.setups_['otto9_cal']= 'Otto.setTrims('+ valuell +','+ valuerl +',' +valuelf +','+ valuerf+','+ valuela+','+ valuera+');';
   var code = '//humanoid calibrated\n';
   return code;
+};
+
+Blockly.Python['otto9_calibrationh']=function(block){
+    var valuell = block.getFieldValue('LL');
+    var valuerl = block.getFieldValue('RL');
+    var valuelf = block.getFieldValue('LF');
+    var valuerf = block.getFieldValue('RF');
+    var valuela = block.getFieldValue('LA');
+    var valuera = block.getFieldValue('RA');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = 'Otto.setTrims('+ valuell +', '+ valuerl +', ' +valuelf +', '+ valuerf+', '+ valuela+', '+ valuera+'); \n';
+    return code;
 };
 
 Blockly.Blocks['otto9_moveh'] = {init: function() {
@@ -559,6 +775,45 @@ Blockly.Arduino['otto9_moveh'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_moveh'] = function(block) {
+    var dropdown_otto_move_sens = block.getFieldValue('otto_move_sens');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = '';
+    switch(dropdown_otto_move_sens) {
+        case 'FORWARD':
+            code = 'Otto.walk(1,' + dropdown_otto_move_speed + ',1) # FORWARD\n';
+            break;
+        case 'BACKWARD':
+            code = 'Otto.walk(1,' + dropdown_otto_move_speed + ',-1) # BACKWARD\n';
+            break;
+        case 'LEFT':
+            code = 'Otto.turn(1,' + dropdown_otto_move_speed + ',1) # LEFT\n';
+            break;
+        case 'RIGHT':
+            code = 'Otto.turn(1,' + dropdown_otto_move_speed + ',-1) # RIGHT\n';
+            break;
+        case 'BENDLEFT':
+            code = 'Otto.bend(1,' + dropdown_otto_move_speed + ',1)\n';
+            break;
+        case 'BENDRIGHT':
+            code = 'Otto.bend(1,' + dropdown_otto_move_speed + ',-1)\n';
+            break;
+        case 'SHAKERIGHT':
+            code = 'Otto.shakeLeg(1,' + dropdown_otto_move_speed + ',1)\n';
+            break;
+        case 'SHAKELEFT':
+            code = 'Otto.shakeLeg(1,' + dropdown_otto_move_speed + ',-1)\n';
+            break;
+        case 'jump':
+            code = 'Otto.jump(1,' + dropdown_otto_move_speed + ')\n';
+            break;
+    }
+    return code;
+};
+
 Blockly.Blocks['otto9_danceh'] = {init: function() {
     this.appendDummyInput().appendField(new Blockly.FieldImage('media/humanoid_moonwalk.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_DANCE_TEXT).appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_DANCE_CHOICE), "otto_dance_movement");
     this.appendDummyInput().appendField(Blockly.Msg.OTTO9_MOVE_SPEED_TEXT).appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_MOVE_SPEED_CHOICE), "otto_move_speed");
@@ -611,6 +866,37 @@ Blockly.Arduino['otto9_danceh'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_danceh'] = function(block) {
+    var dropdown_otto_dance_movement = block.getFieldValue('otto_dance_movement');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = '';
+    switch(dropdown_otto_dance_movement) {
+        case 'moonwalkerLEFT':
+            code = 'Otto.moonwalker(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'moonwalkerRIGHT':
+            code = 'Otto.moonwalker(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+        case 'crusaitoLEFT':
+            code = 'Otto.crusaito(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'crusaitoRIGHT':
+            code = 'Otto.crusaito(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+        case 'flappingFRONT':
+            code = 'Otto.flapping(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', 1)\n';
+            break;
+        case 'flappingBACK':
+            code = 'Otto.flapping(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ', -1)\n';
+            break;
+    }
+    return code;
+};
+
 Blockly.Blocks['otto9_doh'] = { init: function() {
     this.appendDummyInput()   .appendField(new Blockly.FieldImage('media/humanoid_do.png', 48, 48, "*"))   .appendField(Blockly.Msg.OTTO9_DO_TEXT) .appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_DO_CHOICE), "otto_do_movement");
     this.appendDummyInput() .appendField(Blockly.Msg.OTTO9_MOVE_SPEED_TEXT).appendField(new Blockly.FieldDropdown(Blockly.Msg.OTTO9_MOVE_SPEED_CHOICE), "otto_move_speed");
@@ -641,6 +927,17 @@ Blockly.Arduino['otto9_doh'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='Otto.initHUMANOID(PIN_YL, PIN_YR, PIN_RL, PIN_RR, PIN_LA, PIN_RA, true, PIN_NoiseSensor, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
   var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ');\n';
   return code;
+};
+
+Blockly.Python['otto9_doh'] = function(block) {
+    var dropdown_otto_do_movement = block.getFieldValue('otto_do_movement');
+    var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
+    var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ')\n';
+    return code;
 };
 
 Blockly.Blocks['otto9_gestureh'] = {init: function() {
@@ -677,6 +974,16 @@ Blockly.Arduino['otto9_gestureh'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_gestureh'] = function(block) {
+    var dropdown_otto_gesture = block.getFieldValue('otto_gesture');
+    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_gestures'] = 'import gestures';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = 'Otto.playGesture(' + 'gestures.' + dropdown_otto_gesture.toUpperCase() + ')\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_soundh'] = {
   init: function() {
     this.appendDummyInput()
@@ -708,6 +1015,16 @@ Blockly.Arduino['otto9_soundh'] = function(block) {
   Blockly.Arduino.setups_['otto9_init']='Otto.initHUMANOID(PIN_YL, PIN_YR, PIN_RL, PIN_RR, PIN_LA, PIN_RA, true, PIN_NoiseSensor, PIN_Buzzer, PIN_Trigger, PIN_Echo);';
   var code = 'Otto.sing(' + dropdown_otto_sound + ');\n';
   return code;
+};
+
+Blockly.Python['otto9_soundh'] = function(block) {
+    var dropdown_otto_sound = block.getFieldValue('otto_sound');
+    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_songs'] = 'import songs';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = 'Otto.sing(songs.' + dropdown_otto_sound.toUpperCase().substring(2) + ')\n';
+    return code;
 };
 
 Blockly.Blocks['otto9_eyes'] = { init: function() {
@@ -1253,6 +1570,21 @@ Blockly.Arduino['otto9_matrix'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_matrix'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var matrix = '0b';
+    for (var i=0; i<30; i++) {
+        if (this.getFieldValue('otto9_matrix_pixel' + i) == 'TRUE')
+            matrix += '1';
+        else matrix +='0';
+    };
+    var code = 'Otto.putMouth(' + matrix +', false)\n';
+    return code;
+};
+
 Blockly.Blocks["otto9_matrix8x8"] = {  init: function() {
   this.appendDummyInput().appendField('  ').appendField(' 0').appendField(' 1').appendField(' 2').appendField('  3').appendField('  4').appendField(' 5').appendField(' 6').appendField(' 7');
   Blockly.FieldCheckbox.CHECK_CHAR= '▉'
@@ -1342,10 +1674,10 @@ for (var i=0; i<64; i++) {
 
  if (this.getFieldValue('Pixel' + i) != 'rgb(255, 255, 255)') {
      var on = this.getFieldValue('Pixel' + i)== "TRUE"? "1" : "0";
-     var row= i +1 
+     var row= i +1
      {if  (i >= 0 && i <= 7)row=0}{if  (i >= 8 && i < 16)row=1}{if  (i >= 16 && i < 24)row=2}{if  (i >= 24 && i < 32)row=3}
      {if  (i >= 32 && i < 40)row=4}{if  (i >= 40 && i < 48)row=5}{if  (i >= 48 && i < 56)row=6}{if  (i >= 56 && i < 64)row=7}
-     var col= i  
+     var col= i
      {if  (i > 1 && i <= 7)col=i}{if  (i >= 8 && i < 16)col=i-8}{if  (i >= 16 && i < 24)col=i-16}{if  (i >= 24 && i < 32)col=i-24}
      {if  (i >= 32 && i < 40)col=i-32}{if  (i >= 40 && i < 48)col=i-40}{if  (i >= 48 && i < 56)col=i-48}{if  (i >= 56 && i < 64)col=i-56}
      code += ' Otto.setLed('+row+','+col+',' + on + ');\n'
@@ -1353,6 +1685,24 @@ for (var i=0; i<64; i++) {
 };
 for (var i=0; i<8; i++) {if (this.getFieldValue('eyes_pixel' + i) == 'TRUE')row = 0;};
 return code;
+};
+
+Blockly.Python['otto9_matrix8x8'] = function() {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = '';
+    for (var i = 0; i < 64; i++) {
+
+        if (this.getFieldValue('Pixel' + i) != 'rgb(255, 255, 255)') {
+            var on = this.getFieldValue('Pixel' + i) == "TRUE" ? "1" : "0";
+            var row = Math.floor(i / 8);
+            var col = i % 8;
+            code += 'Otto.setLed(' + row + ',' + col + ',' + on + ')\n'
+        }
+    }
+    return code;
 };
 
 Blockly.Blocks['otto9_mouth'] = {  init: function() {
@@ -1381,16 +1731,27 @@ Blockly.Arduino['otto9_mouth'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_mouth'] = function(block) {
+    var dropdown_otto9_mouth_choice = block.getFieldValue('otto9_mouth_choice');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = 'Otto.putMouth(mouths.' + dropdown_otto9_mouth_choice.toUpperCase() + ')\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_mouth#']={ init:function(){
-  this.appendDummyInput()
-  this.appendValueInput("mouth") .appendField(Blockly.Msg.OTTO9_MOUTH_TEXT);
-  this.setInputsInline(true);
-  this.setPreviousStatement(true);
-  this.setNextStatement(true);
-  this.setColour("#59646f");
-  this.setTooltip(Blockly.Msg.OTTO9_MATRIX_TOOLTIP);
-  this.setHelpUrl(Blockly.Msg.OTTO9_HUMANOID_URL);
-}
+      this.appendDummyInput()
+      this.appendValueInput("mouth") .appendField(Blockly.Msg.OTTO9_MOUTH_TEXT);
+      this.setInputsInline(true);
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+      this.setColour("#59646f");
+      this.setTooltip(Blockly.Msg.OTTO9_MATRIX_TOOLTIP);
+      this.setHelpUrl(Blockly.Msg.OTTO9_HUMANOID_URL);
+    }
 };
 
 Blockly.Arduino['otto9_mouth#'] = function(block) {
@@ -1410,6 +1771,20 @@ Blockly.Arduino['otto9_mouth#'] = function(block) {
   + 'delay(50);';
   return code;
 };
+
+Blockly.Python['otto9_mouth#'] = function(block) {
+    var valuemouth = Blockly.Python.valueToCode(block, 'mouth', Blockly.Python.ORDER_ATOMIC);
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = 'Otto.clearMouth()\n'
+        + 'Otto.writeText(str('+valuemouth+'), 50) # show the data with a fast scroll \n'
+        + 'delay(50)\n';
+    return code;
+};
+
 Blockly.Blocks['otto9_matrixp']={ init:function(){
   this.appendDummyInput() .appendField("pixel X")
   this.appendValueInput("X") .setCheck("Number")
@@ -1438,6 +1813,17 @@ Blockly.Arduino['otto9_matrixp'] = function(block) {
     return code;
 };
 
+Blockly.Python['otto9_matrixp'] = function(block) {
+    var valuex = Blockly.Python.valueToCode(block, 'X', Blockly.Python.ORDER_ATOMIC);
+    var valuey = Blockly.Python.valueToCode(block, 'Y', Blockly.Python.ORDER_ATOMIC);
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = 'Otto.setLed('+valuex+','+valuey+',1)\n';
+    return code;
+};
 
 Blockly.Blocks['otto9_matrix_text'] = { init: function() {
     this.appendDummyInput() .appendField(Blockly.Msg.OTTO9_MATRIXTEXT_TEXT).appendField(new Blockly.FieldTextInput('I AM OTTO'), 'input');
@@ -1462,6 +1848,18 @@ Blockly.Arduino['otto9_matrix_text'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_matrix_text'] = function(block) {
+    var text_input = block.getFieldValue('input');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = 'Otto.clearMouth()\n'
+    + 'Otto.writeText('+ '"' + text_input +'"' +',100) # limited to CAPITAL LETTERS NUMBERS : ; < >  = @, MAX.9 characters \n';
+    return code;
+};
+
 Blockly.Blocks["otto9_matrix_brightness"]={init:function(){
     this.appendValueInput("brightness").setCheck("Number") .appendField(Blockly.Msg.matrice+" intensity");
     this.setInputsInline(true);
@@ -1474,6 +1872,16 @@ Blockly.Blocks["otto9_matrix_brightness"]={init:function(){
 Blockly.Arduino["otto9_matrix_brightness"]=function(block){
 	var brightness=Blockly.Arduino.valueToCode(block, "brightness");
     return "Otto.matrixIntensity(" + brightness + ");//the brightness of the display. (0 to 15)\n"
+};
+
+Blockly.Python["otto9_matrix_brightness"]=function(block){
+    var brightness=Blockly.Python.valueToCode(block, "brightness");
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    return "Otto.matrixIntensity(" + brightness + ") #the brightness of the display. (0 to 15)\n"
 };
 
 Blockly.Blocks['otto9_clear'] = { init: function() {
@@ -1496,6 +1904,16 @@ Blockly.Arduino['otto9_clear'] = function(block) {
   Blockly.Arduino.setups_['otto9_matrix']='Otto.initMATRIX( DIN_PIN, CS_PIN, CLK_PIN, LED_DIRECTION);';
   var code = 'Otto.clearMouth();\n';
   return code;
+};
+
+Blockly.Python['otto9_clear'] = function(block) {
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_mouths']='import mouths';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    var code = 'Otto.clearMouth()\n';
+    return code;
 };
 
 Blockly.Blocks['otto9_arms'] = { init: function() {
@@ -1540,6 +1958,25 @@ Blockly.Arduino['otto9_arms'] = function(block) {
   return code;
 };
 
+Blockly.Python['otto9_arms'] = function(block) {
+    var dropdown_otto9_arms_choice = block.getFieldValue('otto9_arms_choice');
+    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
+        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    var code = 'Otto.';
+    switch(dropdown_otto9_arms_choice) {
+        case 'HANDSUP':
+            code += 'handsup()\n';
+            break;
+        case 'HANDWAVE1':
+            code += 'handwave(1)\n';
+            break;
+        case 'HANDWAVE2':
+            code += 'handwave(-1)\n';
+            break;
+    }
+    return code;
+};
 
 /**
  * @fileoverview Helper functions for generating Arduino blocks.

--- a/www/blocs&generateurs/otto.js
+++ b/www/blocs&generateurs/otto.js
@@ -34,9 +34,9 @@ Blockly.Arduino['otto9_home'] = function(block) {
 };
 
 Blockly.Python['otto9_home'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = "Otto.home()\n";
     return code;
 };
@@ -79,9 +79,9 @@ Blockly.Python['otto9_calibration'] = function(block) {
     var valuerl = block.getFieldValue('RL');
     var valuelf = block.getFieldValue('LF');
     var valuerf = block.getFieldValue('RF');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = 'Otto.setTrims('+ valuell +','+ valuerl +',' +valuelf +','+ valuerf+')\n';
     return code;
 };
@@ -103,7 +103,8 @@ Blockly.Arduino['otto9_eeprom'] = function(block) {
 };
 
 Blockly.Python['otto9_eeprom'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
     var code = 'Otto.saveTrimsOnEEPROM()\n';
     return code;
 };
@@ -170,9 +171,9 @@ Blockly.Arduino['otto9_move'] = function(block) {
 Blockly.Python['otto9_move'] = function(block) {
     var dropdown_otto_move_sens = block.getFieldValue('otto_move_sens');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = '';
     switch(dropdown_otto_move_sens) {
         case 'FORWARD':
@@ -265,9 +266,9 @@ Blockly.Python['otto9_dance'] = function(block) {
     var dropdown_otto_dance_movement = block.getFieldValue('otto_dance_movement');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
     var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = '';
     switch(dropdown_otto_dance_movement) {
         case 'moonwalkerLEFT':
@@ -330,9 +331,9 @@ Blockly.Python['otto9_do'] = function(block) {
     var dropdown_otto_do_movement = block.getFieldValue('otto_do_movement');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
     var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ')\n';
     return code;
 };
@@ -365,10 +366,10 @@ Blockly.Arduino['otto9_gesture'] = function(block) {
 
 Blockly.Python['otto9_gesture'] = function(block) {
     var dropdown_otto_gesture = block.getFieldValue('otto_gesture');
-    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_otto9'] = 'import otto9';
     Blockly.Python.definitions_['import_gestures'] = 'import gestures';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = 'Otto.playGesture(' + 'gestures.' + dropdown_otto_gesture.toUpperCase() + ')\n';
     return code;
 };
@@ -401,10 +402,10 @@ Blockly.Arduino['otto9_sound'] = function(block) {
 
 Blockly.Python['otto9_sound'] = function(block) {
     var dropdown_otto_sound = block.getFieldValue('otto_sound');
-    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_otto9'] = 'import otto9';
     Blockly.Python.definitions_['import_songs'] = 'import songs';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = 'Otto.sing(songs.' + dropdown_otto_sound.toUpperCase().substring(2) + ')\n';
     return code;
 };
@@ -443,9 +444,9 @@ Blockly.Arduino['otto9_tone'] = function(block) {
 Blockly.Python['otto9_tone'] = function(block) {
     var dropdown_otto_note = block.getFieldValue('otto_note');
     var dropdown_otto_note_duration = block.getFieldValue('otto_note_duration');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9'] = 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     var code = "Otto._tone(" + dropdown_otto_note + ", " + dropdown_otto_note_duration + ", 1)\n";
     return code;
 };
@@ -470,9 +471,8 @@ Blockly.Arduino['otto9_getdistance'] = function(block) {
 };
 
 Blockly.Python['otto9_getdistance'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-    + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
     var code = 'Otto.getDistance()\n';
     return [code, Blockly.Python.ORDER_ATOMIC];
 };
@@ -501,9 +501,8 @@ Blockly.Arduino['otto9_obstacle'] = function(block) {
 
 Blockly.Python['otto9_obstacle'] = function(block) {
     var dropdown_obstacle = block.getFieldValue('obstacle');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
     var code = '(Otto.getDistance() < ' + dropdown_obstacle +')';
     return [code, Blockly.Python.ORDER_ATOMIC];
 };
@@ -526,9 +525,8 @@ Blockly.Arduino['otto9_getnoise'] = function(block) {
 };
 
 Blockly.Python['otto9_getnoise'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
     var code = 'Otto.getNoise()';
     return [code, Blockly.Python.ORDER_ATOMIC];
 };
@@ -551,9 +549,6 @@ Blockly.Arduino['otto9_touchbutton'] = function(block) {
 };
 
 Blockly.Python['otto9_touchbutton'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
     Blockly.Python.definitions_['touch_pin'] = 'touch1 = TouchPad(Pin(14))'
     var code = 'touch1.read()';
     return [code, Blockly.Arduino.ORDER_ATOMIC];
@@ -586,14 +581,6 @@ Blockly.Arduino['otto9_gyro'] = function(block) {
   return code;
 };
 
-Blockly.Python['otto9_gyro'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
-    var code = "print('we don\'t yet support gyro') # We don't yet support gyro in Python\n";
-    return code;
-};
-
 Blockly.Blocks['otto9_getg'] = {init: function() {
     this.appendDummyInput().appendField(new Blockly.FieldImage('media/sensor_gyro.png', 48, 48, "*")).appendField(Blockly.Msg.OTTO9_GETG_TEXT).appendField(new Blockly.FieldDropdown([["ax", "ax"], ["ay", "ay"], ["az", "az"], ["gx", "gx"], ["gy", "gy"], ["gz", "gz"]]), "otto_getg");
     this.setInputsInline(true);
@@ -619,14 +606,6 @@ Blockly.Arduino['otto9_getg'] = function(block) {
   +'Serial.println(accelgyro.testConnection() ? "MPU6050 connection successful" : "MPU6050 connection failed");\n';
   var code = dropdown_otto_getg;
   return [code, Blockly.Arduino.ORDER_ATOMIC];
-};
-
-Blockly.Python['otto9_getg'] = function(block) {
-Blockly.Python.definitions_['import_otto']='import otto9';
-Blockly.Python.definitions_['init_otto'] = 'Otto = otto9.Otto9()\n'
-    + 'Otto.init(33, 25, 26, 27, True, 34, 4, 2, 15)\n';
-var code = "print('we don\'t yet support gyro') # We don't yet support gyro in Python\n";
-return code;
 };
 
 Blockly.Blocks['otto9_homeh'] = { init: function() {
@@ -657,9 +636,9 @@ Blockly.Arduino['otto9_homeh'] = function(block) {
 };
 
 Blockly.Python['otto9_homeh'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = "Otto.home()\n";
     return code;
 };
@@ -708,9 +687,9 @@ Blockly.Python['otto9_calibrationh']=function(block){
     var valuerf = block.getFieldValue('RF');
     var valuela = block.getFieldValue('LA');
     var valuera = block.getFieldValue('RA');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = 'Otto.setTrims('+ valuell +', '+ valuerl +', ' +valuelf +', '+ valuerf+', '+ valuela+', '+ valuera+'); \n';
     return code;
 };
@@ -778,9 +757,9 @@ Blockly.Arduino['otto9_moveh'] = function(block) {
 Blockly.Python['otto9_moveh'] = function(block) {
     var dropdown_otto_move_sens = block.getFieldValue('otto_move_sens');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = '';
     switch(dropdown_otto_move_sens) {
         case 'FORWARD':
@@ -870,9 +849,9 @@ Blockly.Python['otto9_danceh'] = function(block) {
     var dropdown_otto_dance_movement = block.getFieldValue('otto_dance_movement');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
     var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = '';
     switch(dropdown_otto_dance_movement) {
         case 'moonwalkerLEFT':
@@ -933,9 +912,9 @@ Blockly.Python['otto9_doh'] = function(block) {
     var dropdown_otto_do_movement = block.getFieldValue('otto_do_movement');
     var dropdown_otto_move_speed = block.getFieldValue('otto_move_speed');
     var dropdown_otto_dance_size = block.getFieldValue('otto_dance_size');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = 'Otto.' + dropdown_otto_do_movement + '(1, ' + dropdown_otto_move_speed + ', ' + dropdown_otto_dance_size + ')\n';
     return code;
 };
@@ -976,10 +955,10 @@ Blockly.Arduino['otto9_gestureh'] = function(block) {
 
 Blockly.Python['otto9_gestureh'] = function(block) {
     var dropdown_otto_gesture = block.getFieldValue('otto_gesture');
-    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_otto9'] = 'import otto9';
     Blockly.Python.definitions_['import_gestures'] = 'import gestures';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = 'Otto.playGesture(' + 'gestures.' + dropdown_otto_gesture.toUpperCase() + ')\n';
     return code;
 };
@@ -1019,10 +998,10 @@ Blockly.Arduino['otto9_soundh'] = function(block) {
 
 Blockly.Python['otto9_soundh'] = function(block) {
     var dropdown_otto_sound = block.getFieldValue('otto_sound');
-    Blockly.Python.definitions_['import_otto'] = 'import otto9';
+    Blockly.Python.definitions_['import_otto9'] = 'import otto9';
     Blockly.Python.definitions_['import_songs'] = 'import songs';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = 'Otto.sing(songs.' + dropdown_otto_sound.toUpperCase().substring(2) + ')\n';
     return code;
 };
@@ -1571,10 +1550,9 @@ Blockly.Arduino['otto9_matrix'] = function(block) {
 };
 
 Blockly.Python['otto9_matrix'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var matrix = '0b';
     for (var i=0; i<30; i++) {
         if (this.getFieldValue('otto9_matrix_pixel' + i) == 'TRUE')
@@ -1697,10 +1675,9 @@ return code;
 };
 
 Blockly.Python['otto9_matrix8x8'] = function() {
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = '';
     for (var i = 0; i < 64; i++) {
 
@@ -1742,11 +1719,10 @@ Blockly.Arduino['otto9_mouth'] = function(block) {
 
 Blockly.Python['otto9_mouth'] = function(block) {
     var dropdown_otto9_mouth_choice = block.getFieldValue('otto9_mouth_choice');
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = 'Otto.putMouth(mouths.' + dropdown_otto9_mouth_choice.toUpperCase() + ')\n';
     return code;
 };
@@ -1783,11 +1759,10 @@ Blockly.Arduino['otto9_mouth#'] = function(block) {
 
 Blockly.Python['otto9_mouth#'] = function(block) {
     var valuemouth = Blockly.Python.valueToCode(block, 'mouth', Blockly.Python.ORDER_ATOMIC);
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = 'Otto.clearMouth()\n'
         + 'Otto.writeText(str('+valuemouth+'), 50) # show the data with a fast scroll \n'
         + 'delay(50)\n';
@@ -1825,11 +1800,10 @@ Blockly.Arduino['otto9_matrixp'] = function(block) {
 Blockly.Python['otto9_matrixp'] = function(block) {
     var valuex = Blockly.Python.valueToCode(block, 'X', Blockly.Python.ORDER_ATOMIC);
     var valuey = Blockly.Python.valueToCode(block, 'Y', Blockly.Python.ORDER_ATOMIC);
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = 'Otto.setLed('+valuex+','+valuey+',1)\n';
     return code;
 };
@@ -1859,11 +1833,10 @@ Blockly.Arduino['otto9_matrix_text'] = function(block) {
 
 Blockly.Python['otto9_matrix_text'] = function(block) {
     var text_input = block.getFieldValue('input');
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = 'Otto.clearMouth()\n'
     + 'Otto.writeText('+ '"' + text_input +'"' +',100) # limited to CAPITAL LETTERS NUMBERS : ; < >  = @, MAX.9 characters \n';
     return code;
@@ -1885,11 +1858,10 @@ Blockly.Arduino["otto9_matrix_brightness"]=function(block){
 
 Blockly.Python["otto9_matrix_brightness"]=function(block){
     var brightness=Blockly.Python.valueToCode(block, "brightness");
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     return "Otto.matrixIntensity(" + brightness + ") #the brightness of the display. (0 to 15)\n"
 };
 
@@ -1916,11 +1888,10 @@ Blockly.Arduino['otto9_clear'] = function(block) {
 };
 
 Blockly.Python['otto9_clear'] = function(block) {
-    Blockly.Python.definitions_['import_otto']='import otto9';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
     Blockly.Python.definitions_['import_mouths']='import mouths';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
-    Blockly.Python.definitions_['ledmatrix_init'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_ledmatrix'] = 'Otto.initMatrix(19, 5, 18, 1)\n';
     var code = 'Otto.clearMouth()\n';
     return code;
 };
@@ -1969,9 +1940,9 @@ Blockly.Arduino['otto9_arms'] = function(block) {
 
 Blockly.Python['otto9_arms'] = function(block) {
     var dropdown_otto9_arms_choice = block.getFieldValue('otto9_arms_choice');
-    Blockly.Python.definitions_['import_otto']='import otto9';
-    Blockly.Python.definitions_['otto_init'] = 'Otto = otto9.Otto9()\n'
-        + 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
+    Blockly.Python.definitions_['import_otto9']='import otto9';
+    Blockly.Python.definitions_['declare_otto9'] = 'Otto = otto9.Otto9()\n';
+    Blockly.Python.definitions_['init_otto9h'] = 'Otto.initHUMANOID(23, 22, 33, 25, 26, 27, True, 35, 4, 2, 15)\n';
     var code = 'Otto.';
     switch(dropdown_otto9_arms_choice) {
         case 'HANDSUP':

--- a/www/js/generate_python.js
+++ b/www/js/generate_python.js
@@ -40,12 +40,20 @@ Blockly.Python.finish=function(a) {
 		var e=Blockly.Python.imports_[name];
         e.match(/^(from\s+\S+\s+)?import\s+\S+/) ? imports.push(e) : froms.push(e)
     }
+
+	if ( window.profile[card].cpu == "cortexM0" ) imports.push("from microbit import *");
+
+	// newer code just uses definitions for imports as well.
+	for (var name in Blockly.Python.definitions_) {
+		var def = Blockly.Python.definitions_[name];
+		if (def.match(/^(from\s+\S+\s+)?import\s+\S+/)) {
+			imports.push(def);
+		} else {
+			definitions.push(def);
+		}
+	}
 	if (imports.length) {
 		imports.push('\n');
-	}
-	if ( window.profile[card].cpu == "cortexM0" ) imports.push("from microbit import *");
-	for (var name in Blockly.Python.definitions_) {
-		definitions.push(Blockly.Python.definitions_[name]);
 	}
 	if (definitions.length) {
 		definitions.push('\n');

--- a/www/toolbox/toolbox_lycee.xml
+++ b/www/toolbox/toolbox_lycee.xml
@@ -146,6 +146,9 @@
 		</category>
 		<category name="CAT_ARDUINO_matrice8x8" colour="#747F8A">
 			<block type="otto9_mouth"></block>
+			<block type="otto9_matrix_brightness">
+				<value name="brightness"><shadow type="math_number"><field name="NUM">15</field></shadow></value>
+			</block>
 			<block type="otto9_matrix_text"></block>
 			<block type="otto9_mouth#">
 				<value name="mouth"><shadow type="math_number">	<field name="NUM">10</field></shadow></value>
@@ -156,6 +159,7 @@
 			<value name="Y"><shadow type="math_number">	<field name="NUM">0</field>	</shadow>	</value>
 			</block>
 			<block type="otto9_clear"></block>
+			<block type="otto9_matrix8x8"></block>
 		</category>
 		<category name="CAT_ARDUINO_matrice16x8" colour="#32D900">
 			<block type="otto9_eyes"></block>


### PR DESCRIPTION
Here are the changes for running Otto using python. 
Some minor reformatting of code.
Change to support the newer method of using python.definitions_['import_xxx'] for imports, But still allowed the old method.