### PR TITLE
Update blocklino.css

### DIFF
--- a/www/css/blocklino.css
+++ b/www/css/blocklino.css
@@ -1,4 +1,7 @@
 @CHARSET "UTF-8";
+
+::-webkit-scrollbar { width: 0px; }
+
 html,body {
 	height: 100%
 }


### PR DESCRIPTION
I found a bug in Otto Blockly coding environment. Whenever I right click on Block in workspace area, the height of workspace has been increased and hence vertical scrollbar is als

https://user-images.githubusercontent.com/26852284/103437842-662a2780-4c52-11eb-8f77-a54f59010731.mp4

o increased. I fixed that issue by making small changes in blocklino.css stylesheet.