### PR TITLE
Fix output "dist" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.DS_Store
-/node_modules/
 /compilation/arduino/packages/
 /compilation/arduino/suppr/
 /compilation/arduino/tmp/
@@ -15,3 +14,5 @@
 /compilation/arduino/package_stm_index.json
 /compilation/arduino/package_ustepper_index.json
 /compilation/arduino/inventory.yaml
+/dist
+/node_modules/

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "asar": false,
   "directories": {
    "buildResources": "./build",
-   "output": "../dist"
+   "output": "./dist"
   },
   "nsis": {
    "installerIcon": "build/install.ico",


### PR DESCRIPTION
After building the program, I was wondering where the compiled dist directory was. Then I realized its outside the project dir, which is sub optimal since projects shouldn't touch stuff outside their directory.

This PR fixes the output dir and puts it into the gitignore since it shouldnt get commited.