### PR TITLE
Input text for project name added

### DIFF
--- a/www/css/blocklino.css
+++ b/www/css/blocklino.css
@@ -67,6 +67,12 @@ body {
 	left: 6px;
 	color:white
 }
+#title-project-name {
+	margin-left: 10px;
+    border-radius: 5px;
+	color: black;
+	font-weight: 500;
+}
 #title-bar-btns {
 	-webkit-app-region: no-drag;
 	position: fixed;

--- a/www/index.html
+++ b/www/index.html
@@ -87,8 +87,11 @@
 	<div class="loading"></div>
 	<div id="toptitle">
 		<div id="title">
-            <span><img src="media/icon.png"/><span id="span_blocklino"></span></span>
-		</div>
+            <span><img src="media/icon.png"><span id="span_blocklino"> Otto Blockly</span></span>
+            <input id="title-project-name" type="text" placeholder="Project name"/>
+		<button id="btn_saveXML" class="btn btn-arduino-rect" title="💾 Save">
+					<span class="fa fa-floppy-o fa-lg fa-fw"></span>
+				</button></div>
         <div id="title-bar-btns">
 			<button id="btn_min" type="button" class="btn btn-minmax"><span class="fa fa-minimize fa-lg"></span></button>
 			<button id="btn_max" type="button" class="btn btn-minmax"><span class="fa fa-maximize fa-lg"></span></button>
@@ -137,9 +140,6 @@
 					<span class="fa fa-folder-open fa-lg fa-fw"></span>
 				</button>
 				<input type="file" id="load" accept=".bloc,.xml,.py,.ino" style="display: none;" />
-				<button id="btn_saveXML" class="btn btn-arduino-rect">
-					<span class="fa fa-floppy-o fa-lg fa-fw"></span>
-				</button>
 				<button id="btn_print" class="btn btn-arduino-rect">
 					<span class="fa fa-camera"> </span>
 				</button>

--- a/www/js/blocklino.js
+++ b/www/js/blocklino.js
@@ -767,7 +767,9 @@ BlocklyDuino.cardPicture_change = function() {
 BlocklyDuino.saveino = function() {
     var code = $('#pre_previewArduino').text();
 	var datenow = Date.now();
-	var filename = "arduino"+datenow+".ino";
+	var projectname = document.getElementById("title-project-name").value;
+	var projectname = document.getElementById("title-project-name").value;
+	var filename = projectname+".ino";
  	var element = document.createElement('a');
 	element.setAttribute('href', 'data:text/ino;charset=utf-8,' + encodeURIComponent(code));
 	element.setAttribute('download', filename);
@@ -779,7 +781,9 @@ BlocklyDuino.saveino = function() {
 BlocklyDuino.savepy = function() {
     var code = $('#pre_previewArduino').text();
 	var datenow = Date.now();
-	var filename = "python"+datenow+".py";
+	var projectname = document.getElementById("title-project-name").value;
+	var projectname = document.getElementById("title-project-name").value;
+		var filename = projectname+".py";
  	var element = document.createElement('a');
 	element.setAttribute('href', 'data:text/ino;charset=utf-8,' + encodeURIComponent(code));
 	element.setAttribute('download', filename);
@@ -808,7 +812,9 @@ BlocklyDuino.saveXmlFile = function () {
 		}
 		var data = Blockly.Xml.domToPrettyText(xml);
 		var datenow = Date.now();
-		var filename = "blocklino"+datenow+".bloc";
+		document.getElementById("title-project-name").value === '' ? document.getElementById("title-project-name").value = "Ottocode" : null;
+		var projectname = document.getElementById("title-project-name").value;
+		var filename = projectname+".bloc";
 		var element = document.createElement('a');
 		element.setAttribute('href', 'data:text/bloc;charset=utf-8,' + encodeURIComponent(data));
 		element.setAttribute('download', filename);
@@ -819,7 +825,9 @@ BlocklyDuino.saveXmlFile = function () {
 	} else if (window.localStorage.prog=="arduino"){
 		var code = editor.getValue();
 		var datenow = Date.now();
-		var filename = "arduino"+datenow+".ino";
+		document.getElementById("title-project-name").value === '' ? document.getElementById("title-project-name").value = "Ottocode" : null;
+		var projectname = document.getElementById("title-project-name").value;
+		var filename = projectname+".ino";
 		var element = document.createElement('a');
 		element.setAttribute('href', 'data:text/ino;charset=utf-8,' + encodeURIComponent(code));
 		element.setAttribute('download', filename);
@@ -830,7 +838,9 @@ BlocklyDuino.saveXmlFile = function () {
 	} else {
 		var code = editor.getValue();
 		var datenow = Date.now();
-		var filename = "python"+datenow+".py";
+		document.getElementById("title-project-name").value === '' ? document.getElementById("title-project-name").value = "Ottocode" : null;
+		var projectname = document.getElementById("title-project-name").value;
+		var filename = projectname+".py";
 		var element = document.createElement('a');
 		element.setAttribute('href', 'data:py/ino;charset=utf-8,' + encodeURIComponent(code));
 		element.setAttribute('download', filename);


### PR DESCRIPTION
I added an input text field in the top-title section and moved the save button to the top-title. I added some css lines to make it look like other fields and some javascript lines to capture the value of the text field and add it to the file that will be saved. This will make easier for users to create a name for Ottoblockly files.

Note: 
- It will not work with Electron yet. 
- When open a file it doesn't capture the name of that file. 