### PR TITLE
Get name when load a file & scroll bar for blocks

### DIFF
--- a/www/css/blocklino.css
+++ b/www/css/blocklino.css
@@ -1,6 +1,16 @@
 @CHARSET "UTF-8";
 
-::-webkit-scrollbar { width: 0px; }
+::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(45, 45, 100, .5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
 
 html,body {
 	height: 100%

--- a/www/index.html
+++ b/www/index.html
@@ -125,7 +125,7 @@
 					<span class="fa fa-graduation"></span>
 				</button>
 			<!--	<span id="exampleModalLabel" style="color:white;font-size:4" > </span> -->
-			<input id="title-project-name" type="text" placeholder="Project name"/>
+			<input id="title-project-name" type="text" placeholder="Project name" value=""/>
 		<button id="btn_saveXML" class="btn btn-arduino-rect" >
 					<span class="fa fa-floppy-o fa-lg fa-fw"></span>
 				</button>

--- a/www/js/blocklino.js
+++ b/www/js/blocklino.js
@@ -115,6 +115,7 @@ BlocklyDuino.load = function(event) {
 	var reader = new FileReader();
 	reader.onloadend = function(event) {
 		var target = event.target;
+		document.getElementById('title-project-name').value = files[0].name.substring(0, files[0].name.indexOf('.'));
 		if (target.readyState == 2) {
 			if (files[0].name.endsWith("ino")) {
 				$('#codeORblock').bootstrapToggle("off");


### PR DESCRIPTION
When load a project from computer it gets the name and display it in the project name text input.  Note: when loading an example from the software it didn't get the name of the example. 

Also, I added a visible scroll bar in the blocks palette when the blocks overflow the screen height.